### PR TITLE
Fixing summary-declaration page validation bug with preschool

### DIFF
--- a/frontend/src/components/summary/group/CCOFSummary.vue
+++ b/frontend/src/components/summary/group/CCOFSummary.vue
@@ -140,85 +140,87 @@
             </v-row>
           </v-col>
         </v-row>
-        <v-row class="d-flex justify-start">
-          <v-col cols="12" lg="12" class="pb-0 pt-0">
-            <v-row no-gutters class="d-flex justify-start pt-2">
-              <v-col cols="12" class="d-flex justify-start">
-                <span class="summary-label">Preschool sessions your facility offers per day:</span>
-              </v-col>
-            </v-row>
-          </v-col>
-        </v-row>
-        <v-row class="d-flex justify-start pt-2">
-          <v-col cols="2" lg="1" class="pb-0 pt-0">
-            <v-row no-gutters class="d-flex justify-start">
-              <v-col cols="12" class="d-flex justify-start">
-                <span class="summary-label">Monday</span>
-              </v-col>
-              <v-col class="d-flex justify-start">
-                <v-text-field placeholder="Required" :value="this.funding?.monday" class="summary-value" dense flat solo hide-details readonly :rules="rules.required" ></v-text-field>
-              </v-col>
-            </v-row>
-          </v-col>
-          <v-col cols="2" lg="1" class="pb-0 pt-0">
-            <v-row no-gutters class="d-flex justify-start">
-              <v-col cols="12" class="d-flex justify-start">
-                <span class="summary-label">Tuesday</span>
-              </v-col>
-              <v-col class="d-flex justify-left">
-                <v-text-field placeholder="Required" :value="this.funding?.tusday" class="summary-value" dense flat solo hide-details readonly :rules="rules.required" ></v-text-field>
-              </v-col>
-            </v-row>
-          </v-col>
-          <v-col cols="2" lg="1" class="pb-0 pt-0">
-            <v-row no-gutters class="d-flex justify-start">
-              <v-col cols="12" class="d-flex justify-start">
-                <span class="summary-label">Wednesday</span>
-              </v-col>
-              <v-col class="d-flex justify-start">
-                <v-text-field placeholder="Required" :value="this.funding?.wednesday" class="summary-value" dense flat solo hide-details readonly required :rules="rules.required" ></v-text-field>
-              </v-col>
-            </v-row>
-          </v-col>
-          <v-col cols="2" lg="1" class="pb-0 pt-0">
-            <v-row no-gutters class="d-flex justify-start">
-              <v-col cols="12" class="d-flex justify-start">
-                <span class="summary-label">Thursday</span>
-              </v-col>
-              <v-col class="d-flex justify-start">
-                <v-text-field placeholder="Required" :value="this.funding?.thursday" class="summary-value" dense flat solo hide-details readonly :rules="rules.required" ></v-text-field>
-              </v-col>
-            </v-row>
-          </v-col>
-          <v-col cols="2" lg="1" class="pb-0 pt-0">
-            <v-row no-gutters class="d-flex justify-start">
-              <v-col cols="12" class="d-flex justify-start">
-                <span class="summary-label">Friday</span>
-              </v-col>
-              <v-col class="d-flex justify-start">
-                <v-text-field placeholder="Required" :value="this.funding?.friday" class="summary-value" dense flat solo hide-details readonly :rules="rules.required" ></v-text-field>
-              </v-col>
-            </v-row>
-          </v-col>
-          <v-col cols="2" lg="1" class="pb-0 pt-0">
-            <v-row no-gutters class="d-flex justify-start">
-              <v-col cols="12" class="d-flex justify-start">
-                <span class="summary-label">Total</span>
-              </v-col>
-              <v-col class="d-flex justify-start">
-                <v-text-field placeholder="Required" :value="this.calculateTotal()" class="summary-value" dense flat solo hide-details readonly :rules="rules.required" ></v-text-field>
-              </v-col>
-            </v-row>
-          </v-col>
-          <v-col cols="4" lg="3" class="pb-0 pt-0">
-            <v-row no-gutters class="d-flex justify-start">
-              <v-col cols="12" class="d-flex justify-start">
-                <span class="summary-label pt-1">Is the facility located on school property?</span>
-                <v-text-field placeholder="Required" :value="this.funding?.isSchoolProperty?.toUpperCase()" class="summary-value ml-n5" dense flat solo hide-details readonly :rules="rules.required" ></v-text-field>
-              </v-col>
-            </v-row>
-          </v-col>
-        </v-row>
+        <span v-if="this.funding?.maxPreschool > 0">
+          <v-row class="d-flex justify-start">
+            <v-col cols="12" lg="12" class="pb-0 pt-0">
+              <v-row no-gutters class="d-flex justify-start pt-2">
+                <v-col cols="12" class="d-flex justify-start">
+                  <span class="summary-label">Preschool sessions your facility offers per day:</span>
+                </v-col>
+              </v-row>
+            </v-col>
+          </v-row>
+          <v-row class="d-flex justify-start pt-2">
+            <v-col cols="2" lg="1" class="pb-0 pt-0">
+              <v-row no-gutters class="d-flex justify-start">
+                <v-col cols="12" class="d-flex justify-start">
+                  <span class="summary-label">Monday</span>
+                </v-col>
+                <v-col class="d-flex justify-start">
+                  <v-text-field placeholder="Required" :value="this.funding?.monday" class="summary-value" dense flat solo hide-details readonly :rules="rules.required" ></v-text-field>
+                </v-col>
+              </v-row>
+            </v-col>
+            <v-col cols="2" lg="1" class="pb-0 pt-0">
+              <v-row no-gutters class="d-flex justify-start">
+                <v-col cols="12" class="d-flex justify-start">
+                  <span class="summary-label">Tuesday</span>
+                </v-col>
+                <v-col class="d-flex justify-left">
+                  <v-text-field placeholder="Required" :value="this.funding?.tusday" class="summary-value" dense flat solo hide-details readonly :rules="rules.required" ></v-text-field>
+                </v-col>
+              </v-row>
+            </v-col>
+            <v-col cols="2" lg="1" class="pb-0 pt-0">
+              <v-row no-gutters class="d-flex justify-start">
+                <v-col cols="12" class="d-flex justify-start">
+                  <span class="summary-label">Wednesday</span>
+                </v-col>
+                <v-col class="d-flex justify-start">
+                  <v-text-field placeholder="Required" :value="this.funding?.wednesday" class="summary-value" dense flat solo hide-details readonly required :rules="rules.required" ></v-text-field>
+                </v-col>
+              </v-row>
+            </v-col>
+            <v-col cols="2" lg="1" class="pb-0 pt-0">
+              <v-row no-gutters class="d-flex justify-start">
+                <v-col cols="12" class="d-flex justify-start">
+                  <span class="summary-label">Thursday</span>
+                </v-col>
+                <v-col class="d-flex justify-start">
+                  <v-text-field placeholder="Required" :value="this.funding?.thursday" class="summary-value" dense flat solo hide-details readonly :rules="rules.required" ></v-text-field>
+                </v-col>
+              </v-row>
+            </v-col>
+            <v-col cols="2" lg="1" class="pb-0 pt-0">
+              <v-row no-gutters class="d-flex justify-start">
+                <v-col cols="12" class="d-flex justify-start">
+                  <span class="summary-label">Friday</span>
+                </v-col>
+                <v-col class="d-flex justify-start">
+                  <v-text-field placeholder="Required" :value="this.funding?.friday" class="summary-value" dense flat solo hide-details readonly :rules="rules.required" ></v-text-field>
+                </v-col>
+              </v-row>
+            </v-col>
+            <v-col cols="2" lg="1" class="pb-0 pt-0">
+              <v-row no-gutters class="d-flex justify-start">
+                <v-col cols="12" class="d-flex justify-start">
+                  <span class="summary-label">Total</span>
+                </v-col>
+                <v-col class="d-flex justify-start">
+                  <v-text-field placeholder="Required" :value="this.calculateTotal()" class="summary-value" dense flat solo hide-details readonly :rules="rules.required" ></v-text-field>
+                </v-col>
+              </v-row>
+            </v-col>
+            <v-col cols="4" lg="3" class="pb-0 pt-0">
+              <v-row no-gutters class="d-flex justify-start">
+                <v-col cols="12" class="d-flex justify-start">
+                  <span class="summary-label pt-1">Is the facility located on school property?</span>
+                  <v-text-field placeholder="Required" :value="this.funding?.isSchoolProperty?.toUpperCase()" class="summary-value ml-n5" dense flat solo hide-details readonly :rules="rules.required" ></v-text-field>
+                </v-col>
+              </v-row>
+            </v-col>
+          </v-row>
+        </span>
         <v-row class="d-flex justify-start">
           <v-col cols="12" lg="12" class="pb-0 pt-0">
             <v-row no-gutters class="d-flex justify-start pt-2">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Fixed validation rules on summary-declaration in order to match the rules set forth in maxPreschool on the fundAmount.vue page. 
<!-- Describe your changes in detail -->

added v-if within a span to validate the summary-declaration page. 
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

 Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->