### PR TITLE
report change button enable / disable logic

### DIFF
--- a/frontend/src/components/LandingPage.vue
+++ b/frontend/src/components/LandingPage.vue
@@ -83,7 +83,7 @@
         </template>
       </SmallCard>
 
-      <SmallCard :class="smallCardLayout('OTHERS')" class="col-lg-2" :disable="!isCCOFApproved">
+      <SmallCard :class="smallCardLayout('OTHERS')" class="col-lg-2" :disable="!isReportChangeButtonEnabled">
         <template #content>
           <p class="text-h6">
             Report changes to your licence or service
@@ -101,7 +101,7 @@
               </v-btn>
             </v-col>
             <v-col class="col-12">
-              <v-btn @click="goToReportChange()" :color='buttonColor(!isCCOFApproved)' dark>
+              <v-btn @click="goToReportChange()" :color='buttonColor(!isReportChangeButtonEnabled)' dark>
                 Report a change
               </v-btn>
             </v-col>
@@ -229,7 +229,7 @@ export default {
     ...mapGetters('app', ['renewalYearLabel']),
     ...mapState('app', ['programYearList', 'isRenewal']),
     ...mapState('navBar', ['navBarList']),
-    ...mapState('organization', ['organizationProviderType', 'organizationId', 'organizationName', 'organizationAccountNumber']),
+    ...mapState('organization', ['fundingAgreementNumber', 'organizationAccountNumber', 'organizationProviderType', 'organizationId', 'organizationName', 'organizationAccountNumber']),
     ...mapState('application', ['applicationType', 'programYearId', 'ccofApplicationStatus', 'unlockBaseFunding',
       'unlockDeclaration', 'unlockEcewe', 'unlockLicenseUpload', 'unlockSupportingDocuments', 'applicationStatus']),
     ...mapState('reportChanges', ['userProfileChangeRequests']),
@@ -347,6 +347,12 @@ export default {
     },
     isCCOFApproved() {
       return (this.applicationType === 'RENEW') || (this.ccofStatus === this.CCOF_STATUS_APPROVED);
+    },
+    isReportChangeButtonEnabled() {
+      if (this.organizationAccountNumber && this.fundingAgreementNumber) {
+        return true;
+      }
+      return false;
     },
     isUpdateChangeRequestDisplayed() {
       let changeRequestStatuses = this.userProfileChangeRequests?.map(changeRequest => changeRequest.status);

--- a/frontend/src/components/LandingPage.vue
+++ b/frontend/src/components/LandingPage.vue
@@ -349,10 +349,7 @@ export default {
       return (this.applicationType === 'RENEW') || (this.ccofStatus === this.CCOF_STATUS_APPROVED);
     },
     isReportChangeButtonEnabled() {
-      if (this.organizationAccountNumber && this.fundingAgreementNumber) {
-        return true;
-      }
-      return false;
+      return !!(this.organizationAccountNumber && this.fundingAgreementNumber);
     },
     isUpdateChangeRequestDisplayed() {
       let changeRequestStatuses = this.userProfileChangeRequests?.map(changeRequest => changeRequest.status);


### PR DESCRIPTION
Adding in logic to enable/disable the report changes button.

Button will be enabled if the organization has an organizationAccountNumber and fundingAgreementNumber.

Types of changes
New feature (non-breaking change which adds functionality)