### PR TITLE
increasing heap space to avoid javascript heap out of memory error.

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,7 @@
     "settest": "set NODE_ENV='test'",
     "setlocal": "set NODE_ENV='local'",
     "servecmd": "nodemon ./src/server.js",
-    "start": "node --max-old-space-size=150 ./src/server.js",
+    "start": "node --max-old-space-size=450 ./src/server.js",
     "lint": "node_modules/.bin/eslint . --no-fix --ignore-pattern 'node_modules' --ext .js",
     "lint:fix": "node_modules/.bin/eslint . --fix --ignore-pattern 'node_modules' --ext .js",
     "test": "node_modules/.bin/jest --env node --passWithNoTests",


### PR DESCRIPTION
Limiting to 450mb given our memory allocation on openshift.