### PR TITLE
CCFRI-3801 - Type of Care Not Populating Consistently

### DIFF
--- a/frontend/src/components/CcfriEstimator.vue
+++ b/frontend/src/components/CcfriEstimator.vue
@@ -1212,7 +1212,6 @@ export default {
       this.updateNumberOfChildSubForms();
       this.showEstimatorResults = false;
       this.results = [];
-      this.$refs.form.resetErrorBag(); // necessary to remove validation errors after the field values are removed
       this.$refs.form.resetValidation();
     },
     validateParentFee(child, v) {


### PR DESCRIPTION
Removed  this.$refs.form.resetErrorBag(); as it's not supported with Vue3

<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

CCFRI Estimator Page - Type of Care Not Populating Consistently.
The process for retrieving the facility is broken because of the function resetErrorBag() that is not a Vue3 valid function.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

Removed resetErrorBag() function as it's compatible with Vue3.
resetValidation() function does exactly the same thing.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->