### PR TITLE
fix: synchronous loop for async calls

### DIFF
--- a/frontend/src/components/SummaryDeclaration.vue
+++ b/frontend/src/components/SummaryDeclaration.vue
@@ -685,9 +685,12 @@ export default {
     if (this.$route.path.endsWith('printable')) {
       this.printableVersion = true;
     }
-    await this.getChangeRequestList();
-    await this.loadSummary(this.$route.params?.changeRecGuid);
-    await this.loadData();
+    await Promise.all([
+      this.getChangeRequestList(),
+      this.loadSummary(this.$route.params?.changeRecGuid),
+      this.loadData(),
+    ]);
+
     if (!isEmpty(this.declarationModel)) {
       this.model = cloneDeep(this.declarationModel);
     }


### PR DESCRIPTION
This PR:
- Reduces the complexity of the state manipulation 
- Loads each facility call into a Promise.all so that they may be called in parallel

The result is a more optimized page load times for summary declarations that have a huge number of facilities to look up.