### PR TITLE
Fix TZ settings for displaying submission history dates

### DIFF
--- a/backend/src/components/application.js
+++ b/backend/src/components/application.js
@@ -511,6 +511,7 @@ async function printPdf(req, numOfRetries = 0) {
 function getCurrentDateForPdfFileName() {
   const date = new Date();
   const dateTimeFormatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: "America/Vancouver",
     month: 'short',
   });
   const month = dateTimeFormatter.format(date).toUpperCase();

--- a/frontend/src/components/SubmissionHistory.vue
+++ b/frontend/src/components/SubmissionHistory.vue
@@ -124,7 +124,7 @@ export default {
     getSubmissionDateString(date) {
       if (date) {
         // date display format: YYYY/MM/DD
-        return new Date(date).toLocaleDateString('zh-CN', { year: 'numeric', month: '2-digit', day: '2-digit' });
+        return new Date(date).toLocaleDateString(undefined, { year: 'numeric', month: '2-digit', day: '2-digit' });
       }
       return '- - - -';
     },

--- a/frontend/src/components/requestChanges/ReportChanges.vue
+++ b/frontend/src/components/requestChanges/ReportChanges.vue
@@ -492,7 +492,7 @@ export default {
     getSubmissionDateString(date) {
       if (date) {
         // date display format: YYYY/MM/DD
-        return new Date(date).toLocaleDateString('zh-CN', { year: 'numeric', month: '2-digit', day: '2-digit' });
+        return new Date(date).toLocaleDateString(undefined, { year: 'numeric', month: '2-digit', day: '2-digit' });
       }
       return '- - - -';
     },


### PR DESCRIPTION
Also fixes the date on the submitted document. We're relying on the client machine to display their timezone in this solution.