### PR TITLE
fix for sorting across  pages

### DIFF
--- a/frontend/src/components/SubmissionHistory.vue
+++ b/frontend/src/components/SubmissionHistory.vue
@@ -20,6 +20,7 @@
       fixed-header
       class="elevation-4 my-4"
       :items-per-page="10"
+      must-sort
     >
       <template #item.PDF="{ item }">
         <router-link :to="getPDFPath(item.annotationId)" target="_blank">


### PR DESCRIPTION
Adding must-sort to  ensure sorting applies immediately on click and across all pages. 