### PR TITLE
CCFRI-4748 - remove color primary from v-radio-group

### DIFF
--- a/frontend/src/components/ccfriApplication/AFS/AfsDecisionCard.vue
+++ b/frontend/src/components/ccfriApplication/AFS/AfsDecisionCard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card elevation="2" class="pa-4">
     <div class="mb-2">Please select one of the following options regarding the approvable fee schedule:</div>
-    <v-radio-group v-model="updatedValue" :rules="rules.required" :disabled="readonly" color="primary">
+    <v-radio-group v-model="updatedValue" :rules="rules.required" :disabled="readonly">
       <v-radio label="I accept" :value="AFS_STATUSES.ACCEPT" />
       <div v-if="!readonly && updatedValue === AFS_STATUSES.ACCEPT" class="text-body-2 pl-2">
         After submission please wait to receive notification confirming your approval to participate in CCFRI.

--- a/frontend/src/components/ccofApplication/family/FamilyOrganization.vue
+++ b/frontend/src/components/ccofApplication/family/FamilyOrganization.vue
@@ -61,7 +61,6 @@
                   :disabled="isLocked"
                   :rules="rules.required"
                   inline
-                  color="primary"
                   label="Organization Street Address same as Mailing Address"
                   class="mt-4"
                   @update:model-value="resetStreetAddress"

--- a/frontend/src/components/ccofApplication/group/FacilityInformation.vue
+++ b/frontend/src/components/ccofApplication/group/FacilityInformation.vue
@@ -40,7 +40,6 @@
                 :disabled="isLocked"
                 :rules="rules.required"
                 inline
-                color="primary"
                 label="Is the Facility Street Address the same as the Organization Street Address?"
                 class="application-label mt-6"
                 @update:model-value="resetFacilityAddress"
@@ -72,7 +71,6 @@
                 :disabled="isLocked"
                 :rules="rules.required"
                 inline
-                color="primary"
                 label="Is the Facility Contact the same as the Organization's Authorized Signing Authority Information?"
                 class="application-label mt-6"
                 @update:model-value="resetFacilityContact"
@@ -185,7 +183,6 @@
                     :disabled="isLocked"
                     :rules="rules.required"
                     label="Has this facility or you as the applicant ever received funding under the Child Care Operating Funding Program?"
-                    color="primary"
                     class="application-label"
                   >
                     <v-radio label="No" value="no" />

--- a/frontend/src/components/ccofApplication/group/FundAmount.vue
+++ b/frontend/src/components/ccofApplication/group/FundAmount.vue
@@ -61,7 +61,6 @@
                   :disabled="isLocked"
                   inline
                   label="Are there months when ALL of the programs at this facility are closed for the entire month?"
-                  color="primary"
                   class="application-label"
                   @update:model-value="resetSelectedClosedMonths"
                 >
@@ -428,7 +427,6 @@
               :rules="rules.required"
               inline
               label="Is the facility located on school property?"
-              color="primary"
               class="application-label"
             >
               <v-radio label="Yes" :value="1" />
@@ -493,7 +491,6 @@
               :disabled="isLocked"
               inline
               label="Do you regularly offer extended hours of child care (care before 6:00 am, after 7:00pm or overnight service regularly offered)?"
-              color="primary"
               class="application-label"
               @update:model-value="resetExtendedHoursFields"
             >

--- a/frontend/src/components/ccofApplication/group/OrganizationInformation.vue
+++ b/frontend/src/components/ccofApplication/group/OrganizationInformation.vue
@@ -28,12 +28,7 @@
             </v-row>
 
             <div class="ma-4 mb-2">Type of Organization</div>
-            <v-radio-group
-              v-model="model.organizationType"
-              :disabled="isLocked"
-              :rules="rules.required"
-              color="primary"
-            >
+            <v-radio-group v-model="model.organizationType" :disabled="isLocked" :rules="rules.required">
               <v-radio v-for="item in organizationTypeList" :key="item.id" :label="item.name" :value="item.id" />
             </v-radio-group>
 
@@ -95,7 +90,6 @@
                   :disabled="isLocked"
                   :rules="rules.required"
                   inline
-                  color="primary"
                   label="Organization Street Address same as Mailing Address"
                   class="application-label mt-6"
                   @update:model-value="resetStreetAddress"


### PR DESCRIPTION
The vue/vite upgrade by dependabot (PR #667) broke the v-radio-button component (the user can select multiple buttons). It's fixed by removing color primary from v-radio-group