### PR TITLE
CCFRI-5054 - adding logic to hide Org Closures button and fix some Closures bugs

### DIFF
--- a/frontend/src/components/LandingPage.vue
+++ b/frontend/src/components/LandingPage.vue
@@ -412,7 +412,6 @@ export default {
           body: 'Providers with licensed care facilities can apply for a wage enhancement for Early Childhood Educators (ECEs) they employ directly.',
         },
       ],
-      CCOFCardTitle: 'Apply for Child Care Operating Funding (CCOF) including:',
       isLoadingComplete: false,
       selectedProgramYear: undefined,
     };

--- a/frontend/src/components/LandingPage.vue
+++ b/frontend/src/components/LandingPage.vue
@@ -27,7 +27,7 @@
               <p v-else>Apply for Child Care Operating Funding <strong>(CCOF)</strong> including:</p>
             </div>
             <div v-if="!isCCOFApproved || getActionRequiredApplicationsForCCOFCard?.length > 0">
-              <v-container v-for="item in ccofNewApplicationText" :key="item.infoTitle" class="pa-0" fluid>
+              <v-container v-for="item in CCOF_NEW_APPLICATION_TEXT" :key="item.infoTitle" class="pa-0" fluid>
                 <ul class="pl-6">
                   <li class="pa-0">
                     {{ item.title }}
@@ -398,20 +398,6 @@ export default {
     return {
       input: '',
       showCancelDialog: false,
-      ccofNewApplicationText: [
-        {
-          title: 'CCOF Base Funding',
-          body: '<p><strong>(CCOF)</strong> Base Funding assists eligible licensed family and group child care providers with the day-to-day costs of running a facility.</p><strong> CCOF Base Funding is a prerequisite to participate in CCFRI and ECE-WE.</strong>',
-        },
-        {
-          title: 'Child Care Fee Reduction Initiative (CCFRI) Funding',
-          body: 'The CCFRI offers funding to eligible, licensed child care providers to reduce and stabilize parents’ monthly child care fees.',
-        },
-        {
-          title: 'Early Childhood Educator Wage Enhancement (ECE-WE) Funding',
-          body: 'Providers with licensed care facilities can apply for a wage enhancement for Early Childhood Educators (ECEs) they employ directly.',
-        },
-      ],
       isLoadingComplete: false,
       selectedProgramYear: undefined,
     };
@@ -660,6 +646,21 @@ export default {
     this.RENEW_STATUS_ACTION_REQUIRED = 'ACTION_REQUIRED';
     this.PATHS = PATHS;
 
+    this.CCOF_NEW_APPLICATION_TEXT = [
+      {
+        title: 'CCOF Base Funding',
+        body: '<p><strong>(CCOF)</strong> Base Funding assists eligible licensed family and group child care providers with the day-to-day costs of running a facility.</p><strong> CCOF Base Funding is a prerequisite to participate in CCFRI and ECE-WE.</strong>',
+      },
+      {
+        title: 'Child Care Fee Reduction Initiative (CCFRI) Funding',
+        body: 'The CCFRI offers funding to eligible, licensed child care providers to reduce and stabilize parents’ monthly child care fees.',
+      },
+      {
+        title: 'Early Childhood Educator Wage Enhancement (ECE-WE) Funding',
+        body: 'Providers with licensed care facilities can apply for a wage enhancement for Early Childhood Educators (ECEs) they employ directly.',
+      },
+    ];
+
     await this.loadData();
   },
   methods: {
@@ -792,13 +793,15 @@ export default {
     },
     actionRequiredFacilityRoute(ccfriApplicationId) {
       const application = this.applicationMap?.get(this.selectedProgramYearId);
-      if (this.isCCFRIUnlock(ccfriApplicationId, application)) this.goToCCFRI(ccfriApplicationId, application);
-      else if (this.isNMFUnlock(ccfriApplicationId, application))
+      if (this.isCCFRIUnlock(ccfriApplicationId, application)) {
+        this.goToCCFRI(ccfriApplicationId, application);
+      } else if (this.isNMFUnlock(ccfriApplicationId, application)) {
         this.goToNMF(ccfriApplicationId, this.selectedProgramYearId);
-      else if (this.isRFIUnlock(ccfriApplicationId, application))
+      } else if (this.isRFIUnlock(ccfriApplicationId, application)) {
         this.goToRFI(ccfriApplicationId, this.selectedProgramYearId);
-      else if (this.isAFSUnlock(ccfriApplicationId, application))
+      } else if (this.isAFSUnlock(ccfriApplicationId, application)) {
         this.goToAFS(ccfriApplicationId, this.selectedProgramYearId);
+      }
     },
     buttonColor(isDisabled) {
       return isDisabled ? 'disabledButton' : 'blueButton';

--- a/frontend/src/components/applicationTemplates/v2/group/summary/FacilityInformationSummary.vue
+++ b/frontend/src/components/applicationTemplates/v2/group/summary/FacilityInformationSummary.vue
@@ -44,7 +44,9 @@
       </v-row>
       <div>
         <p class="summary-label">Facility Street Address</p>
+        <p v-if="facilityInfo?.facilityAddress" class="py-2">{{ facilityInfo?.facilityAddress }}</p>
         <v-text-field
+          v-else
           placeholder="Required"
           :model-value="facilityInfo?.facilityAddress"
           class="summary-value"
@@ -103,7 +105,9 @@
       <v-row no-gutters>
         <v-col cols="12" md="4">
           <p class="summary-label">Facility Contact Name</p>
+          <p v-if="facilityInfo?.contactName" class="py-2">{{ facilityInfo?.contactName }}</p>
           <v-text-field
+            v-else
             placeholder="Required"
             :model-value="facilityInfo?.contactName"
             class="summary-value"

--- a/frontend/src/components/applicationTemplates/v2/group/summary/OrganizationSummary.vue
+++ b/frontend/src/components/applicationTemplates/v2/group/summary/OrganizationSummary.vue
@@ -91,7 +91,9 @@
         <v-row no-gutters>
           <v-col cols="12" md="8" class="pr-2">
             <p class="summary-label">{{ legalNameLabel }}</p>
+            <p v-if="summaryModel?.organization?.legalName" class="py-2">{{ summaryModel?.organization?.legalName }}</p>
             <v-text-field
+              v-else
               placeholder="Required"
               :model-value="summaryModel?.organization?.legalName"
               class="summary-value"

--- a/frontend/src/components/ccfriApplication/Closures.vue
+++ b/frontend/src/components/ccfriApplication/Closures.vue
@@ -30,6 +30,7 @@
                 :disabled="isReadOnly"
                 :rules="rules.required"
                 color="primary"
+                @update:model-value="resetClosures"
               >
                 <v-radio label="Yes" :value="CCFRI_HAS_CLOSURE_FEE_TYPES.YES" />
                 <v-radio label="No" :value="CCFRI_HAS_CLOSURE_FEE_TYPES.NO" />

--- a/frontend/src/components/util/ApplicationClosureCard.vue
+++ b/frontend/src/components/util/ApplicationClosureCard.vue
@@ -141,6 +141,7 @@
 import { cloneDeep, isEmpty } from 'lodash';
 import moment from 'moment';
 import { mapState, mapWritableState } from 'pinia';
+import { uuid } from 'vue-uuid';
 
 import AppAlertBanner from '@/components/guiComponents/AppAlertBanner.vue';
 import AppButton from '@/components/guiComponents/AppButton.vue';
@@ -224,7 +225,11 @@ export default {
   methods: {
     addRow(isAddButtonClicked) {
       if (!isAddButtonClicked && !isEmpty(this.updatedClosures)) return;
-      this.updatedClosures.push(this.showApplicationTemplateV1 ? {} : { fullClosure: true });
+      const newClosure = { id: uuid.v1() };
+      if (!this.showApplicationTemplateV1) {
+        newClosure.fullClosure = true;
+      }
+      this.updatedClosures.push(newClosure);
     },
     //builds an array of dates to keep track of all days of the selected closure period.
     //this array is used to check if a user selects an overlapping date
@@ -242,7 +247,7 @@ export default {
     validateClosureDates(obj) {
       // Get all closure dates except for the currently edited row
       const otherClosureDates = this.updatedClosures
-        .filter((dateObj) => dateObj.closureId !== obj.closureId)
+        .filter((dateObj) => dateObj.id !== obj.id || dateObj.closureId !== obj.closureId)
         .reduce((acc, dateObj) => {
           return [...acc, ...this.buildDateArray(dateObj.startDate, dateObj.endDate)];
         }, []);

--- a/frontend/src/mixins/closureMixin.js
+++ b/frontend/src/mixins/closureMixin.js
@@ -45,15 +45,10 @@ export default {
       'showApplicationTemplateV1',
     ]),
     ...mapState(useNavBarStore, ['navBarList', 'changeType', 'isChangeRequest', 'getChangeActionNewFacByFacilityId']),
-    ...mapState(useCcfriAppStore, [
-      'areClosureItemsComplete',
-      'CCFRIFacilityModel',
-      'hasIllegalClosureDates',
-      'loadedModel',
-    ]),
+    ...mapState(useCcfriAppStore, ['areClosureItemsComplete', 'CCFRIFacilityModel', 'loadedModel']),
     ...mapState(useOrganizationStore, ['organizationId']),
     ...mapState(useReportChangesStore, ['changeRequestStatus']),
-    ...mapWritableState(useCcfriAppStore, ['loadedClosures', 'updatedClosures']),
+    ...mapWritableState(useCcfriAppStore, ['hasIllegalClosureDates', 'loadedClosures', 'updatedClosures']),
     isClosuresSectionComplete() {
       return (
         this.CCFRIFacilityModel.hasClosureFees === CCFRI_HAS_CLOSURE_FEE_TYPES.NO ||
@@ -81,6 +76,10 @@ export default {
     updateClosures(updatedClosures) {
       if (isEmpty(updatedClosures)) return;
       this.updatedClosures = cloneDeep(updatedClosures);
+    },
+    resetClosures() {
+      this.updatedClosures = [];
+      this.hasIllegalClosureDates = false;
     },
     hasClosureChanged(originalClosure, updatedClosure) {
       const isAgeGroupsUpdated =


### PR DESCRIPTION
**Enhancements:**
- CCFRI-5054 - Implemented logic to conditionally hide the "Organization Closures" button based on Application CCFRI status of the selected fiscal year.
- Adjusted layout to ensure long text wraps correctly in the Organization Info and Facility Info summary sections

**Bug Fixes:**
- Application Closures Dates validation now correctly triggers when: the provider toggles from "No" to "Yes", and the provider selects "Yes" for the first time (for the question: "Do you charge parent fees at this facility for any closures ...?")
- When switching from "Yes" to "No" (for the question: "Do you charge parent fees at this facility for any closures ...?"): Closure date is now reset properly, which prevents stale validation errors from disabling the Save button unnecessarily.
- When navigating between the Organization Closure page and the Landing page, the application previously loaded an incorrect fiscal year, which led to an inaccurate application state.