### PR TITLE
Added workaround for issue with 406 response from ProviderFiscalProfile.

### DIFF
--- a/backend/src/components/utils.js
+++ b/backend/src/components/utils.js
@@ -343,7 +343,8 @@ async function getChangeActionDetails(changeActionId, changeDetailEntity, change
 function getHttpHeader() {
   return {
     headers: {
-      // Accept: 'text/plain',
+      // D365 Controllers are suddently inconsistent with the returned Content-Type (application/json and text/plain)
+      // so use a wildcard to avoid integration errors
       Accept: '*/*',
       'Content-Type': 'application/json',
       [config.get('dynamicsApi:apiKeyHeader')]: config.get('dynamicsApi:apiKeyValue'),

--- a/backend/src/components/utils.js
+++ b/backend/src/components/utils.js
@@ -343,7 +343,8 @@ async function getChangeActionDetails(changeActionId, changeDetailEntity, change
 function getHttpHeader() {
   return {
     headers: {
-      Accept: 'text/plain',
+      // Accept: 'text/plain',
+      Accept: '*/*',
       'Content-Type': 'application/json',
       [config.get('dynamicsApi:apiKeyHeader')]: config.get('dynamicsApi:apiKeyValue'),
     },

--- a/backend/src/components/utils.js
+++ b/backend/src/components/utils.js
@@ -343,7 +343,7 @@ async function getChangeActionDetails(changeActionId, changeDetailEntity, change
 function getHttpHeader() {
   return {
     headers: {
-      // D365 Controllers are suddently inconsistent with the returned Content-Type (application/json and text/plain)
+      // D365 Controllers are currently inconsistent with their returned Content-Type (application/json and text/plain)
       // so use a wildcard to avoid integration errors
       Accept: '*/*',
       'Content-Type': 'application/json',


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
After the latest deployment the D365 API has unexpected behaviour for the Controllers. ProviderFiscalProfile is returning application/json while others are still returning text/plain.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes
Changed Accept to a wildcard to support all types and avoid regression issues.

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->
