### PR TITLE
CCFRI-5490 - Missing Summary Declaration button text

### DIFF
--- a/frontend/src/components/SummaryDeclaration.vue
+++ b/frontend/src/components/SummaryDeclaration.vue
@@ -299,7 +299,7 @@
           application. We will contact you if more information is required.
         </p>
         <p>
-          <AppButton color="primary" class="mt-4" @click="goToDashboard"> Return to your dashboard </AppButton>
+          <AppButton class="mt-4" @click="goToDashboard"> Return to your dashboard </AppButton>
         </p>
       </template>
     </AppDialog>

--- a/frontend/src/components/guiComponents/AppButton.vue
+++ b/frontend/src/components/guiComponents/AppButton.vue
@@ -53,7 +53,7 @@ export default {
 
 .BC-Gov-PrimaryButton,
 .BC-Gov-PrimaryButton-disabled {
-  background-color: v-bind(color);
+  background-color: #003366;
   border: none;
   border-radius: 4px;
   color: white;

--- a/frontend/src/components/requestChanges/SummaryDeclarationChangeRequest.vue
+++ b/frontend/src/components/requestChanges/SummaryDeclarationChangeRequest.vue
@@ -282,7 +282,7 @@
           application. We will contact you if more information is required.
         </p>
         <p>
-          <AppButton color="primary" class="mt-4" @click="goToDashboard"> Return to your dashboard </AppButton>
+          <AppButton class="mt-4" @click="goToDashboard"> Return to your dashboard </AppButton>
         </p>
       </template>
     </AppDialog>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Fixed issue with button text on Summary Declaration confirmation not being visible.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes
Remove erroneous attributes from Summary Declaration return buttons as they were causing issues with prop-based color.
Removed v-bind(color) from primary as it should always be blue. Secondary buttons are still customizable.

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->