### PR TITLE
CSP udpates to allow inline pdf rendering.

### DIFF
--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -20,7 +20,7 @@ header {
 	Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate"
 	X-Content-Type-Options "nosniff"
 	Strict-Transport-Security "max-age=31536000"
-	Content-Security-Policy "default-src 'self' https://spt.apps.gov.bc.ca https://spm.apps.gov.bc.ca; script-src 'self' https://www2.gov.bc.ca ;style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://use.fontawesome.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://fonts.googleapis.com http://www.w3.org"
+	Content-Security-Policy "default-src 'self' https://spt.apps.gov.bc.ca https://spm.apps.gov.bc.ca; script-src 'self' https://www2.gov.bc.ca data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://use.fontawesome.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://fonts.googleapis.com http://www.w3.org;  worker-src blob:"
 	Referrer-Policy "same-origin"
 	Feature-Policy "fullscreen 'self'; camera 'none'; microphone 'none'"
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
PDF rendering is failing because of CSP policies.

## Types of changes
Added exclusions to Caddyfile.

