### PR TITLE
Added copilot security config

### DIFF
--- a/.copilotignore
+++ b/.copilotignore
@@ -1,0 +1,8 @@
+# Block file types that may contain sensitive configuration or data
+**/*.json
+**/*.yaml
+**/*.env
+**/*.xml
+
+# Block backend config folder
+backend/src/config/**

--- a/ccof.code-workspace
+++ b/ccof.code-workspace
@@ -58,11 +58,11 @@
       "statecode",
     ],
     "github.copilot.enable": {
-      "*": true,
-      "json": false,
-      "yaml": false,
-      "dotenv": false,
-      "xml": false,
+      "*": false,
+      "css": true,
+      "javascript": true,
+      "java": true,
+      "vue": true,
     },
   },
 }

--- a/ccof.code-workspace
+++ b/ccof.code-workspace
@@ -2,36 +2,36 @@
   "folders": [
     {
       "name": "Frontend",
-      "path": "frontend"
+      "path": "frontend",
     },
     {
       "name": "Backend",
-      "path": "backend"
+      "path": "backend",
     },
     {
       "name": "Tests/Cypress E2E",
-      "path": "test/cypress-e2e"
+      "path": "test/cypress-e2e",
     },
     {
       "name": "Tests/Cypress Component",
-      "path": "frontend/tests/cypress"
+      "path": "frontend/tests/cypress",
     },
     {
       "name": "Tests/Selenium",
-      "path": "test/selenium"
+      "path": "test/selenium",
     },
     {
       "name": "Devops/Github",
-      "path": ".github"
+      "path": ".github",
     },
     {
       "name": "Devops/OpenShift",
-      "path": "tools"
+      "path": "tools",
     },
     {
       "name": "All",
-      "path": "."
-    }
+      "path": ".",
+    },
   ],
   "extensions": {
     "recommendations": [
@@ -41,8 +41,8 @@
       "dbaeumer.vscode-eslint",
       "github.copilot",
       "esbenp.prettier-vscode",
-      "soramatiasq.sort-imports"
-    ]
+      "soramatiasq.sort-imports",
+    ],
   },
   "settings": {
     "editor.formatOnSave": true,
@@ -55,7 +55,14 @@
       "idir",
       "licence",
       "mtfi",
-      "statecode"
-    ]
-  }
+      "statecode",
+    ],
+    "github.copilot.enable": {
+      "*": true,
+      "json": false,
+      "yaml": false,
+      "dotenv": false,
+      "xml": false,
+    },
+  },
 }


### PR DESCRIPTION
This PR adds shared GitHub Copilot settings and a .copilotignore file.

**What this does:**
- Prevents Copilot from automatically using certain files (e.g. config files, .env, .json, .yaml) as background context when generating suggestions
- Disables inline Copilot suggestions for all files by default, and enables them only for specified languages
- Helps reduce accidental exposure of sensitive configuration in Copilot suggestions
- Makes Copilot behavior consistent across the team

**What this does NOT do (important):**
- It does not stop Copilot from reading a file if a developer explicitly opens it and asks Copilot to explain or analyze it (for example using Ctrl + I)
- It cannot prevent intentional use of Copilot on these files

In short, this change limits automatic Copilot usage but does not block explicit user actions.