### PR TITLE
CCFRI-7994 - Fix incorrect portal role mapping

### DIFF
--- a/backend/src/components/user.js
+++ b/backend/src/components/user.js
@@ -299,7 +299,7 @@ async function createUser(req, roleId) {
       emailaddress1: req.session.passport.user._json.email,
       ccof_username: getUserName(req),
       // Add a role for new users
-      'ofm_portal_role_id@odata.bind': `/ofm_portal_roles(${roleId})`,
+      'ccof_ccof_portal_id@odata.bind': `/ofm_portal_roles(${roleId})`,
     };
     postOperation('contacts', payload);
   } catch (e) {


### PR DESCRIPTION
In CMS, the Contact entity is shared by both CCOF and OFM. Therefore, there are two different Portal Role mapping fields:
- OFM: ofm_portal_role_id
- CCOF: ccof_ccof_portal_id

This PR updates the CCOF mapping to use the correct field.