### PR TITLE
CCFRI-8018 - Remove renewalYearLabel

### DIFF
--- a/frontend/src/components/LandingPage.vue
+++ b/frontend/src/components/LandingPage.vue
@@ -458,7 +458,7 @@ export default {
   },
   computed: {
     ...mapState(useAuthStore, ['userInfo']),
-    ...mapState(useAppStore, ['renewalYearLabel', 'programYearList']),
+    ...mapState(useAppStore, ['programYearList']),
     ...mapState(useApplicationStore, [
       'latestProgramYearId',
       'applicationIds',

--- a/frontend/src/components/ccofApplication/RenewOrganization.vue
+++ b/frontend/src/components/ccofApplication/RenewOrganization.vue
@@ -2,7 +2,7 @@
   <v-skeleton-loader :loading="isApplicationProcessing" type="table-tbody" class="mb-12">
     <v-container fluid class="px-lg-16">
       <v-form ref="form" v-model="isValidForm">
-        <ApplicationPCFHeader :program-year="renewalYearLabel" />
+        <ApplicationPCFHeader :program-year="formattedProgramYear" />
         <ApplicationChangeRequestInProgressAlert
           v-if="hasActiveChangeRequest"
           :loading="isApplicationProcessing"
@@ -21,7 +21,7 @@
             </v-card-title>
             <div class="px-8 py-4">
               <p>
-                Once these changes have been processed, you may complete your {{ renewalYearLabel }} Program
+                Once these changes have been processed, you may complete your {{ formattedProgramYear }} Program
                 Confirmation Form.
               </p>
               <p class="py-2">
@@ -67,7 +67,6 @@ import NavButton from '@/components/util/NavButton.vue';
 import alertMixin from '@/mixins/alertMixin.js';
 import permissionsMixin from '@/mixins/permissionsMixin.js';
 import ApplicationService from '@/services/applicationService';
-import { useAppStore } from '@/store/app.js';
 import { useApplicationStore } from '@/store/application.js';
 import { useNavBarStore } from '@/store/navBar.js';
 import { useReportChangesStore } from '@/store/reportChanges.js';
@@ -88,9 +87,9 @@ export default {
     };
   },
   computed: {
-    ...mapState(useAppStore, ['renewalYearLabel']),
     ...mapState(useApplicationStore, [
       'applicationId',
+      'formattedProgramYear',
       'isApplicationProcessing',
       'isApplicationSubmitted',
       'renewalApplicationCCOF',

--- a/frontend/src/store/app.js
+++ b/frontend/src/store/app.js
@@ -3,7 +3,6 @@ import { defineStore } from 'pinia';
 import ApiService from '@/common/apiService.js';
 import { useApplicationStore } from '@/store/application.js';
 import { PROGRAM_YEAR_LANGUAGE_TYPES } from '@/utils/constants.js';
-import { formatFiscalYearName } from '@/utils/format';
 
 export const useAppStore = defineStore('app', {
   state: () => ({

--- a/frontend/src/store/app.js
+++ b/frontend/src/store/app.js
@@ -123,9 +123,6 @@ export const useAppStore = defineStore('app', {
     currentProgramYear: (state) => {
       return state.programYearList?.list?.find((year) => year.status === 'CURRENT');
     },
-    renewalYearLabel: (state) => {
-      return formatFiscalYearName(state.programYearList?.renewal?.name);
-    },
     getApplicationTemplateVersion: (state) => (programYearId) => {
       return state?.programYearList.list.find((el) => el.programYearId === programYearId)?.applicationTemplateVersion;
     },


### PR DESCRIPTION
- Replaced renewalYearLabel with formattedProgramYear in RenewOrganization.vue (Banking Information confirmation page) to fix the incorrect program year shown in the header.
- Removed renewalYearLabel since it is no longer used.