### PR TITLE
CCFRI-8082 - Updated get Pending Closure request to use orgId

### DIFF
--- a/backend/src/components/changeRequest.js
+++ b/backend/src/components/changeRequest.js
@@ -2,6 +2,7 @@
 
 const log = require('./logger');
 const { getUserGuid } = require('./utils');
+const { restrictFacilities } = require('../util/common');
 const { MappableObjectForFront, MappableObjectForBack, getMappingString } = require('../util/mapping/MappableObject');
 const { ChangeActionClosureMappings, ChangeActionRequestMappings, ChangeRequestMappings, MtfiMappings, NewFacilityMappings } = require('../util/mapping/ChangeRequestMappings');
 const { DocumentsMappings, UserProfileBaseCCFRIMappings, UserProfileBaseFundingMappings, UserProfileECEWEMappings } = require('../util/mapping/Mappings');
@@ -354,7 +355,8 @@ async function getChangeActionClosure(req, res) {
 async function getChangeActionClosures(req, res) {
   try {
     const response = await getOperation(`ccof_change_action_closures?$select=${getMappingString(ChangeActionClosureMappings)}&${buildFilterQuery(req.query, ChangeActionClosureMappings)}`);
-    const changeActionClosures = response?.value?.map((changeActionClosure) => new MappableObjectForFront(changeActionClosure, ChangeActionClosureMappings).toJSON());
+    let changeActionClosures = response?.value?.map((changeActionClosure) => new MappableObjectForFront(changeActionClosure, ChangeActionClosureMappings).toJSON());
+    changeActionClosures = restrictFacilities(req, changeActionClosures);
     return res.status(HttpStatus.OK).json(changeActionClosures);
   } catch (e) {
     log.error(e);

--- a/backend/src/routes/changeRequest.js
+++ b/backend/src/routes/changeRequest.js
@@ -89,8 +89,7 @@ router.get(
   passport.authenticate('jwt', { session: false }),
   isValidBackendToken,
   validatePermission(PERMISSIONS.VIEW_CLOSURES),
-  validateFacility(),
-  query('facilityId', 'URL query: [facilityId] is required').notEmpty().isUUID(UUID_VALIDATOR_VERSION),
+  query('organizationId', 'URL query: [organizationId] is required').notEmpty().isUUID(UUID_VALIDATOR_VERSION),
   query('programYearId', 'URL query: [programYearId] is required').notEmpty().isUUID(UUID_VALIDATOR_VERSION),
   (req, res) => {
     validationResult(req).throw();

--- a/backend/src/util/mapping/ChangeRequestMappings.js
+++ b/backend/src/util/mapping/ChangeRequestMappings.js
@@ -44,6 +44,7 @@ const ChangeActionRequestMappings = [
 
 const ChangeActionClosureMappings = [
   { back: '_ccof_closure_value', front: 'closureId' },
+  { back: '_ccof_organization_value', front: 'organizationId' },
   { back: '_ccof_facility_value', front: 'facilityId' },
   { back: '_ccof_program_year_value', front: 'programYearId' },
   { back: 'ccof_closure_start_date', front: 'startDate' },

--- a/frontend/src/components/closure/OrganizationClosures.vue
+++ b/frontend/src/components/closure/OrganizationClosures.vue
@@ -242,24 +242,17 @@ export default {
         this.closures = this.closures?.filter((closure) => {
           return closure.closureStatus && closure.closureStatus !== CLOSURE_STATUSES.MINISTRY_REMOVED;
         });
-        await this.getPendingClosureRequestsForApprovedClosures();
+        await this.getPendingClosureRequests();
         this.isLoading = false;
       } catch (error) {
         console.log(error);
         this.setFailureAlert('Failed to load closures');
       }
     },
-    async getPendingClosureRequestsForApprovedClosures() {
-      this.pendingClosureRequests = [];
-      const approvedClosures = this.closures?.filter((closure) => this.hasApprovedStatus(closure));
-      await Promise.all(
-        approvedClosures?.map(async (closure) => {
-          const response = await ClosureService.getPendingChangeActionClosures(
-            closure.facilityId,
-            this.$route.params.programYearGuid,
-          );
-          this.pendingClosureRequests.push(...response);
-        }),
+    async getPendingClosureRequests() {
+      this.pendingClosureRequests = await ClosureService.getPendingChangeActionClosures(
+        this.organizationId,
+        this.$route.params.programYearGuid,
       );
     },
     setClosureToView(closure) {

--- a/frontend/src/services/closureService.js
+++ b/frontend/src/services/closureService.js
@@ -62,11 +62,11 @@ export default {
     }
   },
 
-  async getPendingChangeActionClosures(facilityId, programYearId) {
+  async getPendingChangeActionClosures(organizationId, programYearId) {
     try {
-      if (!facilityId || !programYearId) return [];
+      if (!organizationId || !programYearId) return [];
       const response = await ApiService.apiAxios.get(
-        `${ApiRoutes.CHANGE_ACTION_CLOSURE}?facilityId=${facilityId}&programYearId=${programYearId}&statusCode=${CHANGE_ACTION_CLOSURE_STATUSES.SUBMITTED}`,
+        `${ApiRoutes.CHANGE_ACTION_CLOSURE}?organizationId=${organizationId}&programYearId=${programYearId}&statusCode=${CHANGE_ACTION_CLOSURE_STATUSES.SUBMITTED}`,
       );
       return response?.data;
     } catch (error) {

--- a/frontend/tests/cypress/component/closure/OrganizationClosures.cy.js
+++ b/frontend/tests/cypress/component/closure/OrganizationClosures.cy.js
@@ -138,6 +138,16 @@ describe('<OrganizationClosures /> ', () => {
   });
 
   it('should render table content', () => {
+    const expectedCells = [
+      ['Facility ID'],
+      ['Facility Name', closureData.facilityName],
+      ['Start Date', closureData.startDate],
+      ['End Date', closureData.endDate],
+      ['Status', 'Pending'],
+      ['Payment Eligibility', 'CCFRI'],
+      ['Actions', 'View Details'],
+    ];
+
     interceptAPI();
 
     mountWithPinia({
@@ -152,24 +162,19 @@ describe('<OrganizationClosures /> ', () => {
     cy.wait('@getOrganizationClosures');
     cy.wait('@getPendingClosureRequests');
 
-    cy.contains('th', 'Facility ID');
-    cy.contains('th', 'Facility Name');
-    cy.contains('th', 'Start Date');
-    cy.contains('th', 'End Date');
-    cy.contains('th', 'Status');
-    cy.contains('th', 'Payment Eligibility');
-    cy.contains('th', 'Actions');
-
     cy.get('tbody tr')
       .first()
       .within(() => {
-        cy.get('td').should('have.length', 7);
-        cy.contains('td', closureData.facilityName);
-        cy.contains('td', closureData.startDate);
-        cy.contains('td', closureData.endDate);
-        cy.contains('td', 'Pending');
-        cy.contains('td', 'CCFRI');
-        cy.contains('button', 'View Details');
+        cy.get('td').should('have.length', expectedCells.length);
+
+        cy.get('td').then((cells) => {
+          for (let index = 0; index < cells.length; index++) {
+            const cell = cells[index];
+            for (const text of expectedCells[index]) {
+              cy.wrap(cell).contains(text);
+            }
+          }
+        });
       });
   });
 

--- a/frontend/tests/cypress/component/closure/OrganizationClosures.cy.js
+++ b/frontend/tests/cypress/component/closure/OrganizationClosures.cy.js
@@ -1,6 +1,6 @@
 import OrganizationClosures from '@/components/closure/OrganizationClosures.vue';
 import vuetify from '@/plugins/vuetify';
-import { ApiRoutes, CLOSURE_STATUSES } from '@/utils/constants.js';
+import { ApiRoutes, CHANGE_ACTION_CLOSURE_STATUSES, CLOSURE_STATUSES } from '@/utils/constants.js';
 import { PERMISSIONS } from '@/utils/constants/permissions.js';
 
 const programYearGuid = '43242';
@@ -33,7 +33,16 @@ function interceptAPI() {
   cy.intercept('GET', `${ApiRoutes.CLOSURES}?organizationId=${organizationId}&programYearId=${programYearGuid}`, {
     statusCode: 200,
     body: [closureData],
-  }).as('getLicenseCategories');
+  }).as('getOrganizationClosures');
+
+  cy.intercept(
+    'GET',
+    `${ApiRoutes.CHANGE_ACTION_CLOSURE}?organizationId=${organizationId}&programYearId=${programYearGuid}&statusCode=${CHANGE_ACTION_CLOSURE_STATUSES.SUBMITTED}`,
+    {
+      statusCode: 200,
+      body: [],
+    },
+  ).as('getPendingClosureRequests');
 }
 
 function mountWithPinia({ initialState = {} } = {}) {
@@ -102,7 +111,7 @@ describe('<OrganizationClosures /> ', () => {
         ...createAppStore(),
         auth: {
           isAuthenticated: true,
-          permissions: [permWithoutReqClosure],
+          permissions: permWithoutReqClosure,
         },
       },
     });
@@ -129,16 +138,6 @@ describe('<OrganizationClosures /> ', () => {
   });
 
   it('should render table content', () => {
-    const expectedCells = [
-      ['Facility ID'],
-      ['Facility Name', closureData.facilityName],
-      ['Start Date', closureData.startDate],
-      ['End Date', closureData.endDate],
-      ['Status', 'Pending'],
-      ['Payment Eligibility', 'CCFRI'],
-      ['Actions', 'View Details'],
-    ];
-
     interceptAPI();
 
     mountWithPinia({
@@ -150,19 +149,27 @@ describe('<OrganizationClosures /> ', () => {
       },
     });
 
+    cy.wait('@getOrganizationClosures');
+    cy.wait('@getPendingClosureRequests');
+
+    cy.contains('th', 'Facility ID');
+    cy.contains('th', 'Facility Name');
+    cy.contains('th', 'Start Date');
+    cy.contains('th', 'End Date');
+    cy.contains('th', 'Status');
+    cy.contains('th', 'Payment Eligibility');
+    cy.contains('th', 'Actions');
+
     cy.get('tbody tr')
       .first()
       .within(() => {
-        cy.get('td').should('have.length', expectedCells.length);
-
-        cy.get('td').then((cells) => {
-          for (let index = 0; index < cells.length; index++) {
-            const cell = cells[index];
-            for (const text of expectedCells[index]) {
-              cy.wrap(cell).contains(text);
-            }
-          }
-        });
+        cy.get('td').should('have.length', 7);
+        cy.contains('td', closureData.facilityName);
+        cy.contains('td', closureData.startDate);
+        cy.contains('td', closureData.endDate);
+        cy.contains('td', 'Pending');
+        cy.contains('td', 'CCFRI');
+        cy.contains('button', 'View Details');
       });
   });
 
@@ -180,6 +187,8 @@ describe('<OrganizationClosures /> ', () => {
         },
       },
     });
+    cy.wait('@getOrganizationClosures');
+    cy.wait('@getPendingClosureRequests');
     cy.contains('button', 'Update');
   });
 
@@ -194,13 +203,15 @@ describe('<OrganizationClosures /> ', () => {
         ...createAppStore(),
         auth: {
           isAuthenticated: true,
-          permissions: [permWithoutEditClosure],
+          permissions: permWithoutEditClosure,
         },
         organization: {
           organizationId,
         },
       },
     });
+    cy.wait('@getOrganizationClosures');
+    cy.wait('@getPendingClosureRequests');
     cy.contains('button', 'Update').should('not.exist');
   });
 
@@ -218,6 +229,8 @@ describe('<OrganizationClosures /> ', () => {
         },
       },
     });
+    cy.wait('@getOrganizationClosures');
+    cy.wait('@getPendingClosureRequests');
     cy.contains('button', 'Remove');
   });
 
@@ -232,13 +245,15 @@ describe('<OrganizationClosures /> ', () => {
         ...createAppStore(),
         auth: {
           isAuthenticated: true,
-          permissions: [permWithoutRemoveClosure],
+          permissions: permWithoutRemoveClosure,
         },
         organization: {
           organizationId,
         },
       },
     });
-    cy.contains('button', 'Update').should('not.exist');
+    cy.wait('@getOrganizationClosures');
+    cy.wait('@getPendingClosureRequests');
+    cy.contains('button', 'Remove').should('not.exist');
   });
 });


### PR DESCRIPTION
Updated getPendingClosureRequests to use organizationId instead of fetching by facilityId with await Promise.all, reducing the number of GET requests sent to the backend.