### PR TITLE
CCFRI-7793 - Cancel ECEWE page navigation while application is processing

### DIFF
--- a/frontend/src/components/eceweApplication/EceweEligibility.vue
+++ b/frontend/src/components/eceweApplication/EceweEligibility.vue
@@ -39,7 +39,7 @@
     :is-save-displayed="true"
     :is-save-disabled="isReadOnly"
     :is-next-disabled="!enableButtons"
-    :is-processing="isProcessing"
+    :is-processing="isApplicationProcessing"
     class="mt-12"
     @previous="previous"
     @next="next"
@@ -83,6 +83,9 @@ export default {
   components: { ApplicationPCFHeader, EceweEligibilityQuestionsV1, EceweEligibilityQuestionsV2, NavButton },
   mixins: [alertMixin],
   async beforeRouteLeave(_to, _from, next) {
+    if (this.isApplicationProcessing || this.isLoading) {
+      return next(false);
+    }
     this.setIsStarted(true);
     await this.saveECEWEApplication(false);
     next();
@@ -92,7 +95,6 @@ export default {
       rules,
       model: {},
       isLoading: false, // flag to UI if screen is getting data or not.
-      isProcessing: false, // flag to UI if screen is saving/processing data or not. We do not hide questions when saving, so we need this flag.
       isValidForm: false,
     };
   },
@@ -107,6 +109,7 @@ export default {
       'applicationStatus',
       'unlockEcewe',
       'applicationId',
+      'isApplicationProcessing',
       'showApplicationTemplateV1',
     ]),
     ...mapState(useOrganizationStore, ['organizationProviderType']),
@@ -184,7 +187,7 @@ export default {
       'setFundingModelTypes',
       'setLoadedFacilities',
     ]),
-    ...mapActions(useApplicationStore, ['setIsEceweCompleteInMap', 'setIsEceweComplete']),
+    ...mapActions(useApplicationStore, ['setIsApplicationProcessing', 'setIsEceweCompleteInMap', 'setIsEceweComplete']),
     ...mapActions(useReportChangesStore, ['setCRIsEceweComplete', 'getChangeRequest']),
     ...mapActions(useNavBarStore, ['forceNavBarRefresh']),
 
@@ -295,12 +298,11 @@ export default {
       });
     },
     async saveECEWEApplication(showConfirmation = true) {
-      if (this.isReadOnly) {
+      if (this.isReadOnly || this.isApplicationProcessing) {
         return;
       }
-
+      this.setIsApplicationProcessing(true);
       this.model = this.$refs.eligibilityQuestions.getFormData();
-      this.isProcessing = true;
       try {
         this.updateQuestions();
         this.setEceweModel(this.model);
@@ -361,7 +363,7 @@ export default {
         this.setFailureAlert('An error occurred while saving ECEWE application. Please try again later.');
         console.log(error);
       } finally {
-        this.isProcessing = false;
+        this.setIsApplicationProcessing(false);
       }
     },
   },

--- a/frontend/src/components/eceweApplication/EceweEligibility.vue
+++ b/frontend/src/components/eceweApplication/EceweEligibility.vue
@@ -361,7 +361,7 @@ export default {
         }
       } catch (error) {
         this.setFailureAlert('An error occurred while saving ECEWE application. Please try again later.');
-        console.log(error);
+        console.error(error);
       } finally {
         this.setIsApplicationProcessing(false);
       }

--- a/frontend/src/components/eceweApplication/EceweFacilities.vue
+++ b/frontend/src/components/eceweApplication/EceweFacilities.vue
@@ -39,7 +39,7 @@
         <v-container fluid class="pa-0">
           <v-btn
             v-if="organizationProviderType === ORGANIZATION_PROVIDER_TYPES.GROUP"
-            class="mx-0 justify-end"
+            class="mx-0 mt-4 justify-end"
             dark
             color="#003366"
             :disabled="isReadOnly"
@@ -142,7 +142,7 @@
     :is-save-displayed="true"
     :is-save-disabled="isSaveBtnDisabled || isReadOnly"
     :is-next-disabled="isNextBtnDisabled"
-    :is-processing="isProcessing"
+    :is-processing="isApplicationProcessing"
     @previous="previous"
     @next="next"
     @validate-form="validateForm()"
@@ -179,6 +179,9 @@ export default {
   components: { ApplicationPCFHeader, NavButton },
   mixins: [alertMixin],
   async beforeRouteLeave(_to, _from, next) {
+    if (this.isApplicationProcessing || this.isLoading) {
+      return next(false);
+    }
     await this.saveFacilities(false);
     next();
   },
@@ -188,7 +191,6 @@ export default {
       uiFacilities: [],
       model: {},
       isLoading: false, // flag to UI if screen is getting data or not.
-      isProcessing: false, // flag to UI if screen is saving/processing data or not.
     };
   },
   computed: {
@@ -210,6 +212,7 @@ export default {
       'applicationStatus',
       'unlockEcewe',
       'applicationId',
+      'isApplicationProcessing',
     ]),
     ...mapState(useReportChangesStore, ['isEceweUnlocked', 'changeRequestStatus']),
     isNextBtnDisabled() {
@@ -264,6 +267,7 @@ export default {
     this.ECEWE_FACILITY_UNION_TYPES = ECEWE_FACILITY_UNION_TYPES;
   },
   methods: {
+    ...mapActions(useApplicationStore, ['setIsApplicationProcessing']),
     ...mapActions(useEceweAppStore, [
       'loadECEWE',
       'saveECEWEFacilities',
@@ -348,11 +352,11 @@ export default {
       });
     },
     async saveFacilities(showConfirmation) {
-      if (this.isReadOnly) {
+      if (this.isReadOnly || this.isApplicationProcessing) {
         return;
       }
-      this.isProcessing = true;
       try {
+        this.setIsApplicationProcessing(true);
         if (this.showUnionQuestion) {
           this.resetUnionResponse();
         }
@@ -391,7 +395,7 @@ export default {
           'An error occurred while saving ECEWE facility applications. Please try again later.' + error,
         );
       }
-      this.isProcessing = false;
+      this.setIsApplicationProcessing(false);
     },
   },
 };

--- a/frontend/src/components/eceweApplication/EceweFacilities.vue
+++ b/frontend/src/components/eceweApplication/EceweFacilities.vue
@@ -391,9 +391,8 @@ export default {
           this.setSuccessAlert('Success! ECEWE Facility applications have been saved.');
         }
       } catch (error) {
-        this.setFailureAlert(
-          'An error occurred while saving ECEWE facility applications. Please try again later.' + error,
-        );
+        this.setFailureAlert('An error occurred while saving ECEWE facility applications. Please try again later.');
+        console.error(error);
       }
       this.setIsApplicationProcessing(false);
     },


### PR DESCRIPTION
Prevent navigation away from the ECEWE pages while the application is processing, so duplicate API requests are not triggered when the provider clicks the left navigation bar button multiple times.