### PR TITLE
CCFRI-8168 - Prevent deletion of Organization link when updating facility access

### DIFF
--- a/backend/src/components/contact.js
+++ b/backend/src/components/contact.js
@@ -117,7 +117,9 @@ async function createRawContactFacility(contactId, facilityId) {
 
 async function syncContactFacilities(contactId, incomingFacilityIds = []) {
   try {
-    const response = await getOperation(`ccof_bceid_organizations?$select=ccof_bceid_organizationid,_ccof_facility_value,statecode&$filter=_ccof_businessbceid_value eq ${contactId}`);
+    const response = await getOperation(
+      `ccof_bceid_organizations?$select=ccof_bceid_organizationid,_ccof_facility_value,statecode&$filter=_ccof_businessbceid_value eq ${contactId} and _ccof_facility_value ne null`,
+    );
     const existingLinks = response?.value ?? [];
     const existingFacilityMap = new Map(existingLinks.map((item) => [item._ccof_facility_value, { id: item.ccof_bceid_organizationid, statecode: item.statecode }]));
 


### PR DESCRIPTION
**Summary**
This PR fixes an issue where updating a user's facility access through Manage Users could unintentionally remove the user's Organization link.

**Root Cause**
The Contact-to-Organization link and the Contact-to-Facility link are stored in the same entity. The only difference is that the Organization link has a null Facility value, while Facility links have a populated Facility value.

When updating facility access, the existing logic deleted all matching relationship records, including the Organization link.

**Fix**
Added a filter to exclude records where Facility = null.

**Expected Result**
Updating facility access only update Facility links. The user's Organization link remains unchanged.